### PR TITLE
Fixes for filenames, string writing, -r on Ubuntu, requirements update

### DIFF
--- a/helpers/manifestMbdbParser.py
+++ b/helpers/manifestMbdbParser.py
@@ -39,7 +39,7 @@ def mbdbParser(manifest_mbdb_path, input_dir, output_dir, logger):
 
         '''Create domain path if it doesnt exist'''
         domain = (record.Domain.String).decode("utf-8")
-        domain_path = os.path.join(output_dir + "\\" + str(domain))
+        domain_path = os.path.join(output_dir, str(domain))
         if os.path.isdir(domain_path):
             pass
         else:
@@ -62,14 +62,17 @@ def mbdbParser(manifest_mbdb_path, input_dir, output_dir, logger):
 
                 '''Do some fun reversing strings to get the directory of the path so that we can copy the file properly'''
                 dest_path = os.path.join(output_dir, domain, path)
-                dest_path = dest_path.replace("/", "\\")
-                reversed_dest_path = dest_path[::-1]
-                dest_path_root_reversed = reversed_dest_path.split('\\', 1)[-1]
-                dest_path_root = dest_path_root_reversed[::-1]
+                dest_path_root = os.path.dirname(dest_path)
+                # Ensure no Windows-incompatible characters
+                def safe_char(char):
+                    if char in {"*",'"',"/","\\",":","|","?"}:
+                        return "-"
+                    else:
+                        return char
+                dest_filename =  "".join(safe_char(char) for char in os.path.basename(dest_path))
+                dest_path = os.path.join(dest_path_root, dest_filename)
                 if os.path.isdir(dest_path_root):
                     copyfile(file_path, dest_path)
                 else:
                     os.makedirs(dest_path_root)
                     copyfile(file_path, dest_path)
-
-

--- a/helpers/writer.py
+++ b/helpers/writer.py
@@ -25,39 +25,39 @@ def writeToTxt(backup_list, application_list, output_file, logger):
     output = open(output_file, "w+")
 
     output.write("DEVICE BACKUP INFO\n" +
-                 "Device Name: \t" + backup_list[0] + "\n" +
-                 "Product Name: \t" + backup_list[1] + "\n" +
-                 "Product Model: \t" + backup_list[2] + "\n" +
-                 "Phone Number: \t" + backup_list[3] + "\n" +
-                 "iOS Version: \t" + backup_list[4]+ "\n" +
+                 "Device Name: \t" + str(backup_list[0]) + "\n" +
+                 "Product Name: \t" + str(backup_list[1]) + "\n" +
+                 "Product Model: \t" + str(backup_list[2]) + "\n" +
+                 "Phone Number: \t" + str(backup_list[3]) + "\n" +
+                 "iOS Version: \t" + str(backup_list[4]) + "\n" +
                  "Backup Completetion: \t" + str(backup_list[5]) + "\n" +
                  "Backup Complete Write: \t" + str(backup_list[6]) + "\n" +
-                 "Users & Computers Connected to: \t\n" + backup_list[7] + "\n" +
+                 "Users & Computers Connected to: \t\n" + str(backup_list[7]) + "\n" +
                  "Is Passcode Set: \t" + str(backup_list[8]) + "\n" +
                  "Is Encrypted: \t" + str(backup_list[9]) + "\n" +
-                 "GUID: \t" + backup_list[10] + "\n" +
-                 "ICCID: \t" + backup_list[11] + "\n" +
-                 "IMEI: \t" + backup_list[12] + "\n" +
-                 "MEID: \t" + backup_list[13] + "\n" +
-                 "Serial Number: \t" + backup_list[14] + "\n" +
+                 "GUID: \t" + str(backup_list[10]) + "\n" +
+                 "ICCID: \t" + str(backup_list[11]) + "\n" +
+                 "IMEI: \t" + str(backup_list[12]) + "\n" +
+                 "MEID: \t" + str(backup_list[13]) + "\n" +
+                 "Serial Number: \t" + str(backup_list[14]) + "\n" +
                  "Is Full Backup: \t" + str(backup_list[15]) + "\n" +
-                 "Version: \t" + backup_list[16] + "\n" +
-                 "iTunes Version: \t" + backup_list[17] +  "\n\n")
+                 "Version: \t" + str(backup_list[16]) + "\n" +
+                 "iTunes Version: \t" + str(backup_list[17]) +  "\n\n")
 
     output.write("\nAPPLICATIONS INSTALLED\n")
     for app in application_list:
-        output.write("App Name: \t" + app[2] + "\n" +
-                     "Device Installed on: \t" + app[0] + "\n" +
+        output.write("App Name: \t" + str(app[2]) + "\n" +
+                     "Device Installed on: \t" + str(app[0]) + "\n" +
                      "Purchase Date: \t" + str(app[5]) + "\n" +
-                     "Apple ID: \t" + app[3] + "\n" +
-                     "Apple ID Name: \t" + app[4] + "\n" +
-                     "Device Installed on Serial Number: \t" + app[1] + "\n" +
+                     "Apple ID: \t" + str(app[3]) + "\n" +
+                     "Apple ID Name: \t" + str(app[4]) + "\n" +
+                     "Device Installed on Serial Number: \t" + str(app[1]) + "\n" +
                      "Is Possibly Sideloaded: \t" + str(app[6]) + "\n" +
-                     "App Version: \t" + app[7] + "\n" +
+                     "App Version: \t" + str(app[7]) + "\n" +
                      "Is Auto Downloaded: \t" + str(app[8]) + "\n" +
                      "Is Purchased Redownloaded: \t" + str(app[9]) + "\n" +
-                     "Publisher: \t" + app[10] + "\n" +
-                     "Full App Name: \t" + app[11] + "\n\n"
+                     "Publisher: \t" + str(app[10]) + "\n" +
+                     "Full App Name: \t" + str(app[11]) + "\n\n"
                      )
     output.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-pathlib-revisited
+pathlib-revised
 biplist
 pycryptodome
 construct>=2.9
+kaitaistruct


### PR DESCRIPTION
Hi there, many thanks for making this script available! It was just what I needed.

Here are some changes I made to get things working on Windows 10 20H2 and Ubuntu 20.04 for an iPhone 4 backup:

1. writer.py: was trying to concatenate None objects with output strings, so wrapped all list objects in str() when concatenating.
2. manifestMbdbParser.py: my backup had some files with ':' in the filename which Windows wouldn't allow, so added a check on the filename before copying.
3. manifestMbdbParser.py: updated method to get domain_path and dest_path_root, which corrects file output location on Ubuntu when using -r.
4. requirements.txt: 'kaitaistruct' added, 'pathlib-revised' corrected.

Thanks again!
John