### PR TITLE
remove biplist and replace it with plistlib

### DIFF
--- a/helpers/encryptedDbParser.py
+++ b/helpers/encryptedDbParser.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 
 import os
 import helpers.deserializer as deserializer
-from biplist import *
+import plistlib
 import logging
 import plistlib
 import datetime

--- a/helpers/manifestDbParser.py
+++ b/helpers/manifestDbParser.py
@@ -9,7 +9,7 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 import helpers.deserializer as deserializer
-from biplist import *
+import plistlib
 import logging
 import plistlib
 import datetime

--- a/helpers/plist_parser.py
+++ b/helpers/plist_parser.py
@@ -208,11 +208,13 @@ def parsePlists(input_dir, output_dir, out_type, decrypt, logger):
         info_plist_copy = os.path.join(output_dir, plist_copy, "BACKUP", "Info.plist")
         manifest_plist_copy = os.path.join(output_dir, plist_copy, "BACKUP", "Manifest.plist")
 
-        plist_data = readPlist(manifest_plist_path)
-        plist_data['IsEncrypted'] = False
-        writePlist(plist_data, manifest_plist_copy)
+        with open(manifest_plist_path, "rb") as fh:
+            plist_data = plistlib.load(fh)
 
-        manifest_plist_copy = os.path.join(output_dir, plist_copy, "BACKUP", "Manifest.plist")
+        plist_data['IsEncrypted'] = False
+
+        with open(manifest_plist_copy, "wb") as fh:
+            plistlib.dump(plist_data, fh)
 
         copyfile(status_plist_path, status_plist_copy)
         copyfile(info_plist_path, info_plist_copy)

--- a/helpers/plist_parser.py
+++ b/helpers/plist_parser.py
@@ -7,7 +7,7 @@
    ------------
 '''
 
-from biplist import *
+import plistlib
 from helpers import writer
 from helpers.structs import sinfHelper, frpdHelper
 import os
@@ -50,7 +50,7 @@ def readApps(apps, info_plist, logger):
 
         iTunesBinaryPlist = app.get('iTunesMetadata', {})
 
-        iTunesPlist = readPlistFromString(iTunesBinaryPlist)
+        iTunesPlist = plistlib.loads(iTunesBinaryPlist)
 
         '''Find Apple ID & Purchase Date'''
         downloadInfo = iTunesPlist.get('com.apple.iTunesStore.downloadInfo', {})
@@ -135,10 +135,13 @@ def readPlists(status_plist_path, manifest_plist_path, info_plist_path, logger, 
     if not os.path.exists(status_plist_path):
         status_plist = None
     else:
+        with open(status_plist_path, "rb") as f:
+            status_plist = plistlib.load(f)
 
-        status_plist = readPlist(status_plist_path)
-    manifest_plist = readPlist(manifest_plist_path)
-    info_plist = readPlist(info_plist_path)
+    with open(manifest_plist_path, "rb") as f:
+        manifest_plist = plistlib.load(f)
+    with open(info_plist_path, "rb") as f:
+        info_plist = plistlib.load(f)
 
 
 

--- a/helpers/recreator.py
+++ b/helpers/recreator.py
@@ -10,7 +10,7 @@
 
 '''
 
-from biplist import *
+import plistlib
 import os
 from helpers import manifestDbParser, manifestMbdbParser, encryptedDbParser
 import sys

--- a/helpers/recreator.py
+++ b/helpers/recreator.py
@@ -23,7 +23,9 @@ def startRecreate(input_dir, output_dir, password, decrypt_only, logger):
 
     '''Check encryption'''
     manifest_plist_path = os.path.join(input_dir, "Manifest.plist")
-    manifest_plist = readPlist(manifest_plist_path)
+    with open(manifest_plist_path, "rb") as fh:
+        manifest_plist = plistlib.load(fh)
+
     encrypted = manifest_plist.get("IsEncrypted", {})
     version = float(manifest_plist.get("Version", {}))
 

--- a/helpers/writer.py
+++ b/helpers/writer.py
@@ -23,7 +23,7 @@ def OpenDb(inputPath, logger):
 '''Write to a plain ole txt file'''
 def writeToTxt(backup_list, application_list, output_file, logger):
     output = open(output_file, "w+")
-
+    backup_list = [str(i) for i in backup_list]
     output.write("DEVICE BACKUP INFO\n" +
                  "Device Name: \t" + backup_list[0] + "\n" +
                  "Product Name: \t" + backup_list[1] + "\n" +

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-pathlib-revisited
 biplist
-pycryptodome
-construct>=2.9
+git:https://github.com/combs/PyConstruct
+PyCryptodome
+pathlib_revised
+kaitaistruct


### PR DESCRIPTION
These changes let iTunes_Backup_Reader function, at least in decrypt mode, with Python 3.9+. I think there might be some deeper flaws in the txt/csv/db export which I haven't chased down, as they seem to produce empty output. But I think those are caused by other Python3 changes (e.g. concatenating `None` with strings) and not the replacement of `biplist`.